### PR TITLE
fix: Replace deprecated inflight package with newer node-gyp version

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,11 @@
     "ts-jest": "^29.1.0",
     "ts-node-dev": "^2.0.0"
   },
+  "overrides": {
+    "sqlite3": {
+      "node-gyp": "^11.1.0"
+    }
+  },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",


### PR DESCRIPTION
Fixes #10 ## Changes - Added package.json override to force sqlite3 to use node-gyp@11.1.0 - This removes the deprecated inflight package warning by ensuring all instances use the newer version - All tests passing ## Testing - Ran full test suite - Verified node-gyp version is correctly overridden - Confirmed removal of inflight warning ## Impact - Removes memory leak warning - Improves stability - No breaking changes