### PR TITLE
fix: Replace deprecated @npmcli/move-file using npm override

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
   "overrides": {
     "sqlite3": {
       "node-gyp": "^11.1.0"
-    }
+    },
+    "@npmcli/move-file": "@npmcli/fs@^3.1.0"
   },
   "jest": {
     "preset": "ts-jest",


### PR DESCRIPTION
This PR fixes #9 by using npm overrides to replace @npmcli/move-file with @npmcli/fs.

## Changes
- Added npm override to replace @npmcli/move-file with @npmcli/fs@^3.1.0
- Keeps existing sqlite3 and node-gyp overrides
- No code changes required

## Testing
- All tests pass
- No functional changes
- Deprecation warning for @npmcli/move-file is resolved

## Notes
- This is a clean solution that doesn't require changing any code
- Uses npm's built-in override functionality
- Maintains all existing functionality